### PR TITLE
Update react-native-svg dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",
     "npm-watch": "^0.1.6",
-    "react": "^15.4.0",
-    "react-native": "^0.38.0",
+    "react": "~15.4.0",
+    "react-native": "^0.41.2",
     "react-native-svg": "^5.0.2"
   },
   "peerDependencies": {
-    "react-native": ">=0.40",
+    "react-native": ">=0.41",
     "react-native-svg": "5.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "npm-watch": "^0.1.6",
     "react": "^15.4.0",
     "react-native": "^0.38.0",
-    "react-native-svg": "^4.4.0"
+    "react-native-svg": "^5.0.2"
   },
   "peerDependencies": {
-    "react-native": ">=0.38",
-    "react-native-svg": "4.x"
+    "react-native": ">=0.40",
+    "react-native-svg": "5.x"
   }
 }


### PR DESCRIPTION
This PR updates the dependency on React Native SVG and peerDependency on React Native to be at least 5.x and 0.40 respectively

closes #3 