### PR TITLE
Fix #21: Allow PropTypes.number as the type of the style prop to fix warning on react-native-web

### DIFF
--- a/src/components/SvgIcon.js
+++ b/src/components/SvgIcon.js
@@ -63,7 +63,7 @@ SvgIcon.propTypes = {
     name: PropTypes.string.isRequired,
     stroke: PropTypes.string,
     strokeWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    style: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    style: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.number]),
     svgs: PropTypes.object.isRequired,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     viewBox: PropTypes.string


### PR DESCRIPTION
Fixes #21 